### PR TITLE
Grunt Production

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,7 +185,6 @@ module.exports = function(grunt) {
     ]);
 
 
-
     /**
      * Default Tasks
      */
@@ -195,5 +194,23 @@ module.exports = function(grunt) {
      * Staging Tasks
      */
     grunt.registerTask('staging', ['dev']);
+
+    /**
+     * Staging Tasks
+     */
+    grunt.registerTask('staging', ['dev']);
+
+    /**
+     *
+     * Production Tasks
+     *
+     */
+    grunt.registerTask('prod', [
+        'css',
+        'javascript',
+        'copy'
+    ]);
+
+
 
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt-autoprefixer": "^0.8.1",
     "grunt-browser-sync": "^2.2.0",
     "grunt-contrib-copy": "~0.6.0",
+    "grunt-contrib-cssmin": "^1.0.1",
     "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-uglify": "*",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
Not having a lot of experience with Grunt, I'm wondering what the best way of getting the production code to the CDN based on a version tag. What I'm thinking at this point, is that the production code will end up on the CDN server in the following configuration: 
- `/<major version>/<major.minor version>/main.css`
- `/<major version>/<major.minor version>/<scripts>.js`

Then additionally we would make a symlink to to the latest major version of the code that we would default people to running:
- `/<major version>/latest/main.css`
- `/<major version>/latest/<scripts>.js`

Thoughts @tpitre?