### PR TITLE
Adding synclisteners back and removing ShareThis code that was causing console errors

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -12,9 +12,9 @@ ie = "scss,DS_Store,less"
 id = "scss,.svn,.sass-cache"
 
 // choose if these services should be loaded in the nav and their ports
-autoReloadNav  = "true"
+autoReloadNav  = "false"
 autoReloadPort = "8002"
-pageFollowNav  = "true"
+pageFollowNav  = "false"
 pageFollowPort = "8003"
 
 // whether the qr code generator should be loaded automatically in the nav

--- a/core/styleguide/js/code-pattern.js
+++ b/core/styleguide/js/code-pattern.js
@@ -7,11 +7,11 @@
  */
 
 var codePattern = {
-	
+
 	codeOverlayActive:  false,
 	codeEmbeddedActive: false,
 	targetOrigin: (window.location.protocol === "file:") ? "*" : window.location.protocol+"//"+window.location.host,
-	
+
 	/**
 	* toggle the annotation feature on/off
 	* based on the great MDN docs at https://developer.mozilla.org/en-US/docs/Web/API/window.postMessage
@@ -20,27 +20,27 @@ var codePattern = {
 	receiveIframeMessage: function(event) {
 		
 		var data = (typeof event.data !== "string") ? event.data : JSON.parse(event.data);
-		
+
 		// does the origin sending the message match the current host? if not dev/null the request
 		if ((window.location.protocol != "file:") && (event.origin !== window.location.protocol+"//"+window.location.host)) {
 			return;
 		}
-		
+
 		if (data.codeToggle !== undefined) {
-			
+
 			var els, i;
-			
+
 			// if this is an overlay make sure it's active for the onclick event
 			codePattern.codeOverlayActive  = false;
 			codePattern.codeEmbeddedActive = false;
-			
+
 			// see which flag to toggle based on if this is a styleguide or view-all page
 			if ((data.codeToggle == "on") && (document.getElementById("sg-patterns") !== null)) {
 				codePattern.codeEmbeddedActive = true;
 			} else if (data.codeToggle == "on") {
 				codePattern.codeOverlayActive  = true;
 			}
-			
+
 			// if comments embedding is turned off make sure to hide the annotations div
 			if (!codePattern.codeEmbeddedActive && (document.getElementById("sg-patterns") !== null)) {
 				els = document.getElementsByClassName("sg-code");
@@ -48,27 +48,27 @@ var codePattern = {
 					els[i].style.display = "none";
 				}
 			}
-			
+
 			// if comments overlay is turned on add the has-comment class and pointer
 			if (codePattern.codeOverlayActive) {
-				
+
 				var obj = JSON.stringify({ "codeOverlay": "on", "lineage": lineage, "lineageR": lineageR, "patternPartial": patternPartial, "patternState": patternState, "cssEnabled": cssEnabled });
 				parent.postMessage(obj,codePattern.targetOrigin);
-				
+
 			} else if (codePattern.codeEmbeddedActive) {
-				
+
 				// if code embedding is turned on simply display them
 				els = document.getElementsByClassName("sg-code");
 				for (i = 0; i < els.length; ++i) {
 					els[i].style.display = "block";
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 };
 
 // add the onclick handlers to the elements that have an annotations

--- a/core/templates/index.mustache
+++ b/core/templates/index.mustache
@@ -124,6 +124,7 @@
 	<script src="styleguide/js/annotations-viewer.js?{{ cacheBuster }}"></script>
 	<script src="styleguide/js/code-viewer.js?{{ cacheBuster }}"></script>
 	{{> websockets }}
+  <script src="styleguide/js/synclisteners.js?{{ cacheBuster }}"></script>
 
 	<script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/source/_patterns/00-atoms/00-meta/_01-foot.mustache
+++ b/source/_patterns/00-atoms/00-meta/_01-foot.mustache
@@ -25,7 +25,6 @@
 
     <script src="../../js/jquery-2.0.0b2.js" type="text/javascript"></script>
     <script src="../../js/script.min.js" type="text/javascript"></script>
-    <script src="//s7.addthis.com/js/250/addthis_widget.js#pubid=ra-4ed4fc0e60966005" type="text/javascript"></script>
 
     <!-- PATTERN LAB SCRIPTS // DO NOT REMOVE FOR PATTERN LAB -->
     {% pattern-lab-foot %}


### PR DESCRIPTION
I was able to track down the console errors to the ShareThis script included on each page in the footer. I removed it, but let me know if you'd like to try something else in its place. [This has been my go-to](http://sharingbuttons.io/) for sharing functionality lately. 

I also put synclisteners.js back. Once the ShareThis bug got cleared up, it revealed another bug caused by synclisteners.js not being available. 

#127