### PR TITLE
#149 Moved post installation commands to grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,10 +35,16 @@ module.exports = function(grunt) {
         },
 
         mkdir: {
+            dev: {
+                options: {
+                    mode: 0750,
+                    create: ['public/styleguide']
+                }
+            },
             prod: {
                 options: {
                     mode: 0777,
-                    create: ['cdn/<%= major_version %>/<%= version %>/css', 'cdn/<%= major_version %>/<%= version %>/js', 'cdn/<%= major_version %>/<%= version %>/images']
+                    create: ['cdn/<%= major_version %>/<%= version %>/css', 'cdn/<%= major_version %>/<%= version %>/js', 'cdn/<%= major_version %>/<%= version %>/images', 'cdn/<%= major_version %>/<%= version %>/styleguide']
                 }
             }
         },
@@ -147,7 +153,19 @@ module.exports = function(grunt) {
                         cwd: 'source/',
                         src: ['<%= copyFiles %>'],
                         dest: 'cdn/<%= major_version %>/<%= version %>/'
-                    }
+                    },
+                    {
+                        expand: true,
+                        cwd: 'core/styleguide',
+                        src: '**',
+                        dest: 'public/styleguide/',
+                    },
+                    {
+                        expand: true,
+                        cwd: 'core/styleguide',
+                        src: '**',
+                        dest: 'cdn/<%= major_version %>/<%= version %>/styleguide/',
+                    }  
                 ]
             }
         },
@@ -300,11 +318,12 @@ module.exports = function(grunt) {
      * Dev tasks
      */
     grunt.registerTask('dev', [
+        'mkdir:dev',
+        'copy',
         'css',
         'javascript',
         'shell:patternlab',
         'images',
-        'copy',
         'add_comment:dev'
     ]);
 
@@ -313,12 +332,12 @@ module.exports = function(grunt) {
      */
     grunt.registerTask('prod', [
         'mkdir:prod',
+        'copy',
         'sass:prod',
         'autoprefixer:prod',
         'uglify:prod',
         'shell:patternlab',
         'images',
-        'copy',
         'symlink',
         'add_comment'
     ]);

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "patternlab-md2json": "^0.1.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "mkdir -p public && cp -r core/styleguide/ public/styleguide/"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#149 Moved post installation commands to grunt for cross platform portability

OS specific post installation commands specified in package.json removed and grunt mkdir & contrib-copy plugins utilized to achieve same functionality but allowing for cross platform portability.
Copy task moved up before shell:patternlab tasks to ensure pattern lab finds styleguide.html and does not ask for manual intervention to copy core/styleguide to public/styleguide