### PR TITLE
Made comment structure consistent

### DIFF
--- a/source/_data/data.json
+++ b/source/_data/data.json
@@ -835,10 +835,12 @@
       }
     ]
   },
-  "single_comment_avatar": "//placeimg.com/32/32/people",
-  "single_comment_date": "9 days ago",
-  "single_comment_byline": "Bob Smith",
-  "single_comment_text": "Vivamus sollicitudin ipsum vel rutrum facilisis. Vestibulum eu cursus massa. Donec faucibus velit eu enim dapibus, sed scelerisque nibh finibus. Praesent imperdiet, leo ut ullamcorper facilisis, felis neque vestibulum mi, in vehicula turpis libero vestibulum eros. Nunc ac lectus id dui eleifend dignissim.",
+  "single_comment" : {
+    "comment_avatar": "//placeimg.com/32/32/people",
+    "comment_date": "9 days ago",
+    "comment_byline": "Bob Smith",
+    "comment_text": "Vivamus sollicitudin ipsum vel rutrum facilisis. Vestibulum eu cursus massa. Donec faucibus velit eu enim dapibus, sed scelerisque nibh finibus. Praesent imperdiet, leo ut ullamcorper facilisis, felis neque vestibulum mi, in vehicula turpis libero vestibulum eros. Nunc ac lectus id dui eleifend dignissim."
+  },
   "comments": {
     "comment": [
       {

--- a/source/_patterns/01-molecules/components/comment.mustache
+++ b/source/_patterns/01-molecules/components/comment.mustache
@@ -1,14 +1,14 @@
 <div class="comment--inner">
   <div class="comment__avatar round">
-    <img alt="" src="{{{ single_comment_avatar }}}" class="avatar" height="50" width="50">
+    <img alt="" src="{{{ single_comment.comment_avatar }}}" class="avatar" height="50" width="50">
   </div>
   <div class="comment__body spacing--quarter">
     <div class="comment__meta">
-      <span class="byline font--secondary--s gray can-be--white theme--secondary-text-color"><a href="">{{{ single_comment_byline }}}</a></span>
+      <span class="byline font--secondary--s gray can-be--white theme--secondary-text-color"><a href="">{{{ single_comment.comment_byline }}}</a></span>
       <span class="divider">|</span>
-      <span class="pub_date font--secondary--s gray can-be--white">{{{ single_comment_date }}}</span><span class="comment__edit-link font--secondary--s theme--primary-text-color"><a class="comment-edit-link" href="">(Edit)</a></span>
+      <span class="pub_date font--secondary--s gray can-be--white">{{{ single_comment.comment_date }}}</span><span class="comment__edit-link font--secondary--s theme--primary-text-color"><a class="comment-edit-link" href="">(Edit)</a></span>
     </div>
-    <p class="comment__content">{{{ single_comment_text }}}</p>
+    <p class="comment__content">{{{ single_comment.comment_text }}}</p>
     <div class="comment__reply">
       <a href="" class="font--secondary--s theme--primary-text-color">Reply</a>
     </div>


### PR DESCRIPTION
The comments structure is currently inconsistent see ticket #165  for details. This change removes the single_comment prefix and aligns single comments with the other comments in ALPs.