### PR TITLE
Updated accordion pattern to correctly reflect differences present in…

### DIFF
--- a/source/_patterns/01-molecules/components/accordion.twig
+++ b/source/_patterns/01-molecules/components/accordion.twig
@@ -3,7 +3,7 @@
   {% for item in accordion_list %}
   <div class="accordion__item spacing--quarter">
     <div class="accordion__heading js-toggle-parent va--middle"><span class="icon icon--m accordion__arrow">{% include 'atoms-icon-arrow-right' with {'fill_class': 'fill--blue'} %}</span> <span class="font--secondary--m dib">{{ item.accordion_heading }}</span></div>
-    <div class="accordion__content">{% include 'molecules-media-block' with {'block_inner_class': 'block__row'} %}</div>
+    <div class="accordion__content">{% include 'molecules-media-block' with {'block_inner_class': 'block__row', 'media_block_default': item.media_block_default } %}</div>
   </div>
   {% endfor %}
 </div> <!-- /.accordion -->


### PR DESCRIPTION
I finally got a chance to check the updates I made to allow different content to show within the accordion. The data changes remain valid however with mustache it automatically includes the child elements context when passing to a sub-template. With twig, one has to explicitly include it. I had built this based on the mustache template, however, I realise we have moved to the twig. I have therefore updated the twig template to allow the data to be passed correctly to the sub-template. See #176 for the original issue