### PR TITLE
Adding Drupal export Grunt command and updating readme. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /vendor
 /source--mustache
 /cdn
+/source/drupal-patterns
 
 # Ignore IDE-specific files
 *.sublime-project

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,6 +143,20 @@ module.exports = function(grunt) {
                         dest: 'cdn/<%= major_version %>/<%= version %>/'
                     }
                 ]
+            },
+            drupalPatterns: {
+                files: [
+                    {
+                        expand: true,
+                        cwd: 'source/_patterns/',
+                        src: ['**/*.twig'],
+                        dest: 'source/drupal-patterns/',
+                        rename: function(dest, src) {
+                            return dest + src.replace('.twig', '.html.twig');
+                        },
+                        filter: 'isFile'
+                    }
+                ]
             }
         },
 
@@ -280,6 +294,13 @@ module.exports = function(grunt) {
      */
     grunt.registerTask('images', [
         'imagemin'
+    ]);
+
+    /**
+     * Drupal pattern exporting
+     */
+    grunt.registerTask('export-drupal-patterns', [
+        'copy:drupalPatterns'
     ]);
 
     /**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ This repository contains the front-end code for the Seventh Day Adventist projec
 
 This creates all patterns, the styleguide, and the pattern lab site as well as a local server for development.
 
+### Twig Include Syntax
+In order to play nice with environments outside of Pattern Lab, we use the default [Twig include syntax](https://twig.sensiolabs.org/doc/2.x/functions/include.html) over the Pattern Lab shorthand.
+
+**Don't do this:**
+```twig
+{% include 'templates-home' %}
+```
+
+**Do this:**
+```twig
+{% include '@templates/home@complete.twig' %}
+```
+
 ### Drupal Pattern Exporting
 For Drupal projects utilizing ALPS twig files, you'll need to run the pattern export command in order to generate the Drupal-specific file naming.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This creates all patterns, the styleguide, and the pattern lab site as well as a
 For Drupal projects utilizing ALPS twig files, you'll need to run the pattern export command in order to generate the Drupal-specific file naming.
 
 - Create a directory named "drupal-patterns" in `/source/`
-- run `grunt export-drupal-patterns` - this will copy all patterns from the `/source/` directory and rename the `.twig` file extensions to `.html.twig`
+- run `grunt export-drupal-patterns` - this will copy all patterns from the `/source/_patterns/` directory and rename the `.twig` file extensions to `.html.twig`
 
 ## Project Standards
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This creates all patterns, the styleguide, and the pattern lab site as well as a
 ### Drupal Pattern Exporting
 For Drupal projects utilizing ALPS twig files, you'll need to run the pattern export command in order to generate the Drupal-specific file naming.
 
-- Create a directory named "drupal-patterns" in `/source/_patterns/`
-- run `grunt export-drupal-patterns` - this will copy all patterns from the `/source/_patterns/` directory and rename the `.twig` file extensions to `.html.twig`
+- Create a directory named "drupal-patterns" in `/source/`
+- run `grunt export-drupal-patterns` - this will copy all patterns from the `/source/` directory and rename the `.twig` file extensions to `.html.twig`
 
 ## Project Standards
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ This repository contains the front-end code for the Seventh Day Adventist projec
 
 This creates all patterns, the styleguide, and the pattern lab site as well as a local server for development.
 
+### Drupal Pattern Exporting
+For Drupal projects utilizing ALPS twig files, you'll need to run the pattern export command in order to generate the Drupal-specific file naming.
+
+- Create a directory named "drupal-patterns" in `/source/_patterns/`
+- run `grunt export-drupal-patterns` - this will copy all patterns from the `/source/_patterns/` directory and rename the `.twig` file extensions to `.html.twig`
+
 ## Project Standards
 
 ### Front-End General Best Practices


### PR DESCRIPTION
### Drupal Pattern Exporting
For Drupal projects utilizing ALPS twig files, you'll need to run the pattern export command in order to generate the Drupal-specific file naming.

- Create a directory named "drupal-patterns" in `/source/`
- run `grunt export-drupal-patterns` - this will copy all patterns from the `/source/_patterns/` directory and rename the `.twig` file extensions to `.html.twig`

cc/ @reganking

Closes #197