### PR TITLE
Fixing the reverse layout bug in Safari.

### DIFF
--- a/source/css/_layout.wrappers.scss
+++ b/source/css/_layout.wrappers.scss
@@ -134,7 +134,7 @@
 .shift-right--fluid {
   width: 100%;
   @include media('>large') {
-    width: 32%;
+    width: 31%;
   }
 }
 


### PR DESCRIPTION
This fixes the bug in #204, allowing the layouts to look identical in Safari and Chrome.