### PR TITLE
#231 Extra space on carousel description background

### DIFF
--- a/source/css/_objects.carousels.scss
+++ b/source/css/_objects.carousels.scss
@@ -162,7 +162,6 @@
 }
 .carousel__item-dek {
   padding-top: rem(5);
-  width: 100%;
   @include media('<=medium') {
     display: none;
   }


### PR DESCRIPTION
Fixes the extra space issue in the carousel description. Closes #231 