### PR TITLE
v3.x – Add variable for theme name & color combos

### DIFF
--- a/source/css/_settings.themes.scss
+++ b/source/css/_settings.themes.scss
@@ -152,17 +152,14 @@
 }
 
 // Generate primary color palettes.
-@include theme-primary(u-theme--emperor, $c-emperor);
-@include theme-primary(u-theme--earth, $c-earth);
-@include theme-primary(u-theme--grapevine, $c-grapevine);
-@include theme-primary(u-theme--denim, $c-denim);
-@include theme-primary(u-theme--campfire, $c-campfire);
-@include theme-primary(u-theme--treefrog, $c-treefrog);
-@include theme-primary(u-theme--ming, $c-ming);
+@each $name, $color in $u-primary-themes {
+  @include theme-primary($name, $color);
+}
 
 // Generate secondary color palettes.
-@include theme-secondary(u-theme--warm, $c-warm);
-@include theme-secondary(u-theme--cool, $c-cool);
+@each $name, $color in $u-secondary-themes {
+  @include theme-secondary($name, $color);
+}
 
 /**
  * Dark Theme

--- a/source/css/_settings.variables.scss
+++ b/source/css/_settings.variables.scss
@@ -66,6 +66,27 @@ $c-dark--light: #303030;
 $c-dark--dark: #252525;
 
 /**
+ * Primary Themes
+ */
+$u-primary-themes: (
+  u-theme--emperor:   $c-emperor,
+  u-theme--earth:     $c-earth,
+  u-theme--grapevine: $c-grapevine,
+  u-theme--denim:     $c-denim,
+  u-theme--campfire:  $c-campfire,
+  u-theme--treefrog:  $c-treefrog,
+  u-theme--ming:      $c-ming,
+);
+
+/**
+ * Secondary Themes
+ */
+$u-secondary-themes: (
+  u-theme--warm:  $c-warm,
+  u-theme--cool:  $c-cool,
+);
+
+/**
  * Typography
  */
 $ff-font: 'Noto Sans', Georgia, Times, "Times New Roman", serif;


### PR DESCRIPTION
_(Same as the pull request for v2.x)_

This allows theme developers for various platforms to make use of these values programmatically via SCSS. For example, we have an inline SVG background in our SCSS that we want to color with the current theme’s primary color. The only way to do so is to loop through all of the theme names (class names applied to the body tag) and primary colors and create versions of the SVG for each one. Without such handy, loopable variables, we’re left manually recreating the list by hand and risking getting it wrong and getting out of sync with future themes or theme changes.