### PR TITLE
master – Add variables for theme names & color combos

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -347,7 +347,7 @@ module.exports = function(grunt) {
       },
       options: {
         watchTask: true,
-        proxy: "alps.dev"
+        proxy: "alps.test"
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,43 @@ This repository contains the front-end code for the Seventh Day Adventist projec
 
 - [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally)
 - run `composer install`
-- Set up your local dev url to be `alps.dev`
+- Set up your local dev url to be `alps.test` (instructions below)
 - [Install node globally](https://docs.npmjs.com/getting-started/installing-node)
 - run `npm install` (may need to be run as `sudo`)
 - run `grunt`
 
 This creates all patterns, the styleguide, and the pattern lab site as well as a local server for development.
+
+#### Setting Up `alps.test` Local Development Domain
+
+##### Using MAMP
+
+1. Grab MAMP from [mamp.info/en/downloads](https://www.mamp.info/en/downloads/) and install it.
+1. Once all of the MAMP files have been installed, set up a virtual host for the project:
+    1. Edit `/Applications/MAMP/conf/apache/httpd.conf`, find the line which says `# Virtual hosts`, and uncomment the `Include …/httpd-vhosts.conf` line after it.
+    1. Edit `/Applications/MAMP/conf/apache/extra/httpd-vhosts.conf`, comment out the 2 example `<VirtualHost>` blocks, and add:
+        ```apache
+        <VirtualHost *:80>
+          ServerName alps.test
+          DocumentRoot "/full/path/to/the/alps/project/files"
+        </VirtualHost>
+        ```
+    1. Edit `/etc/hosts` (you will need root privileges to do so), add the following line:
+        ```hosts
+        127.0.0.1 alps.test
+        ```
+1. Start the MAMP application.
+1. Before you “Start Servers”, go to “Preferences…”:
+    1. Go to the “Ports” tab.
+    1. Click on the “Set Web & MySQL ports to 80 & 3306” button.
+    1. Click “OK” to save this prefence and close the preferences dialog box.
+1. Click on “Start Servers” – you will likely need to enter your user password to allow access to port 80.
+1. Navigate to [alps.test](http://alps.test) in your browser.
+
+##### Using MAMP Pro
+
+_(Documentation needed)_
+
 
 ### Twig Include Syntax
 In order to play nice with environments outside of Pattern Lab, we use the default [Twig include syntax](https://twig.sensiolabs.org/doc/2.x/functions/include.html) over the Pattern Lab shorthand.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ This creates all patterns, the styleguide, and the pattern lab site as well as a
         ```apache
         <VirtualHost *:80>
           ServerName alps.test
-          DocumentRoot "/full/path/to/the/alps/project/files"
+          DocumentRoot "/full/path/to/alps/public"
         </VirtualHost>
         ```
+        Set the `DocumentRoot` to the full path to the `public` directory in the project files; e.g. `/Users/dallas/Code/alps/public`.
     1. Edit `/etc/hosts` (you will need root privileges to do so), add the following line:
         ```hosts
         127.0.0.1 alps.test

--- a/source/css/_modifier.colors.scss
+++ b/source/css/_modifier.colors.scss
@@ -124,32 +124,13 @@
 }
 
 // Theme colors
-.bg--emperor {
-  background-color: $emperor;
-}
-.bg--earth {
-  background-color: $earth;
-}
-.bg--grapevine {
-  background-color: $grapevine;
-}
-.bg--denim {
-  background-color: $denim;
-}
-.bg--campfire {
-  background-color: $campfire;
-}
-.bg--treefrog {
-  background-color: $treefrog;
-}
-.bg--ming {
-  background-color: $ming;
-}
-.bg--cool {
-  background-color: $cool;
-}
-.bg--warm {
-  background-color: $warm;
+@each $name, $color in map-merge(
+  $primary-themes,
+  $secondary-themes
+) {
+  .bg--#{$name} {
+    background-color: $color;
+  }
 }
 .bg--dark-light {
   background-color: $dark-light;
@@ -174,32 +155,13 @@
     width: rem(15);
     background-color: $blue;
   }
-  &--emperor:before {
-    background-color: $emperor;
-  }
-  &--earth:before {
-    background-color: $earth;
-  }
-  &--grapevine:before {
-    background-color: $grapevine;
-  }
-  &--denim:before {
-    background-color: $denim;
-  }
-  &--campfire:before {
-    background-color: $campfire;
-  }
-  &--treefrog:before {
-    background-color: $treefrog;
-  }
-  &--ming:before {
-    background-color: $ming;
-  }
-  &--cool:before {
-    background-color: $cool;
-  }
-  &--warm:before {
-    background-color: $warm;
+  @each $name, $color in map-merge(
+    $primary-themes,
+    $secondary-themes
+  ) {
+    &--#{$name}:before {
+      background-color: $color;
+    }
   }
   &--blue:before {
     background-color: $blue;

--- a/source/css/_settings.themes.scss
+++ b/source/css/_settings.themes.scss
@@ -141,17 +141,14 @@
 
 
 // Generate primary color palettes.
-@include theme-primary(theme--emperor, $emperor);
-@include theme-primary(theme--earth, $earth);
-@include theme-primary(theme--grapevine, $grapevine);
-@include theme-primary(theme--denim, $denim);
-@include theme-primary(theme--campfire, $campfire);
-@include theme-primary(theme--treefrog, $treefrog);
-@include theme-primary(theme--ming, $ming);
+@each $name, $color in $primary-themes {
+  @include theme-primary($name, $color);
+}
 
 // Generate secondary color palettes.
-@include theme-secondary(theme--warm, $warm);
-@include theme-secondary(theme--cool, $cool);
+@each $name, $color in $secondary-themes {
+  @include theme-secondary($name, $color);
+}
 
 /**
  * Dark Theme

--- a/source/css/_settings.themes.scss
+++ b/source/css/_settings.themes.scss
@@ -4,7 +4,7 @@
 
 // Primary color themed elements.
 @mixin theme-primary($name, $primary-color) {
-  .#{$name} {
+  .theme--#{$name} {
     // Text colors
     .theme--primary-text-color,
     .theme--primary-text-color a {
@@ -52,7 +52,7 @@
 
 // Secondary color themed elements.
 @mixin theme-secondary($name, $secondary-color) {
-  .#{$name} {
+  .theme--#{$name} {
     // Text colors
     .theme--secondary-text-color,
     .theme--secondary-text-color a {

--- a/source/css/_settings.variables.scss
+++ b/source/css/_settings.variables.scss
@@ -73,6 +73,29 @@ $dark-light: #303030;
 $dark-dark: #252525;
 
 /**
+ * Primary Themes
+ */
+
+$primary-themes: (
+  theme--emperor:   $emperor,
+  theme--earth:     $earth,
+  theme--grapevine: $grapevine,
+  theme--denim:     $denim,
+  theme--campfire:  $campfire,
+  theme--treefrog:  $treefrog,
+  theme--ming:      $ming,
+);
+
+/**
+ * Secondary Themes
+ */
+
+$secondary-themes: (
+  theme--warm:  $warm,
+  theme--cool:  $cool,
+);
+
+/**
  * Social Colors
  */
 

--- a/source/css/_settings.variables.scss
+++ b/source/css/_settings.variables.scss
@@ -77,13 +77,13 @@ $dark-dark: #252525;
  */
 
 $primary-themes: (
-  theme--emperor:   $emperor,
-  theme--earth:     $earth,
-  theme--grapevine: $grapevine,
-  theme--denim:     $denim,
-  theme--campfire:  $campfire,
-  theme--treefrog:  $treefrog,
-  theme--ming:      $ming,
+  emperor:   $emperor,
+  earth:     $earth,
+  grapevine: $grapevine,
+  denim:     $denim,
+  campfire:  $campfire,
+  treefrog:  $treefrog,
+  ming:      $ming,
 );
 
 /**
@@ -91,8 +91,8 @@ $primary-themes: (
  */
 
 $secondary-themes: (
-  theme--warm:  $warm,
-  theme--cool:  $cool,
+  warm:  $warm,
+  cool:  $cool,
 );
 
 /**


### PR DESCRIPTION
This allows theme developers for various platforms to make use of these values programmatically via SCSS. For example, we have an inline SVG background in our SCSS that we want to color with the current theme’s primary color. The only way to do so is to loop through all of the theme names (class names applied to the body tag) and primary colors and create versions of the SVG for each one. Without such handy, loopable variables, we’re left manually recreating the list by hand and risking getting it wrong and getting out of sync with future themes or theme changes.