### PR TITLE
v2.x – Add variables for theme names & color combos

### DIFF
--- a/source/css/_settings.themes.scss
+++ b/source/css/_settings.themes.scss
@@ -141,17 +141,14 @@
 
 
 // Generate primary color palettes.
-@include theme-primary(theme--emperor, $emperor);
-@include theme-primary(theme--earth, $earth);
-@include theme-primary(theme--grapevine, $grapevine);
-@include theme-primary(theme--denim, $denim);
-@include theme-primary(theme--campfire, $campfire);
-@include theme-primary(theme--treefrog, $treefrog);
-@include theme-primary(theme--ming, $ming);
+@each $name, $color in $primary-themes {
+  @include theme-primary($name, $color);
+}
 
 // Generate secondary color palettes.
-@include theme-secondary(theme--warm, $warm);
-@include theme-secondary(theme--cool, $cool);
+@each $name, $color in $secondary-themes {
+  @include theme-secondary($name, $color);
+}
 
 /**
  * Dark Theme

--- a/source/css/_settings.variables.scss
+++ b/source/css/_settings.variables.scss
@@ -66,6 +66,29 @@ $dark-light: #303030;
 $dark-dark: #252525;
 
 /**
+ * Primary Themes
+ */
+
+$primary-themes: (
+  theme--emperor:   $emperor,
+  theme--earth:     $earth,
+  theme--grapevine: $grapevine,
+  theme--denim:     $denim,
+  theme--campfire:  $campfire,
+  theme--treefrog:  $treefrog,
+  theme--ming:      $ming,
+);
+
+/**
+ * Secondary Themes
+ */
+
+$secondary-themes: (
+  theme--warm:  $warm,
+  theme--cool:  $cool,
+);
+
+/**
  * Social Colors
  */
 $twitter-blue: #13C4F8;


### PR DESCRIPTION
This allows theme developers for various platforms to make use of these values programmatically via SCSS. For example, we have an inline SVG background in our SCSS that we want to color with the current theme’s primary color. The only way to do so is to loop through all of the theme names (class names applied to the body tag) and primary colors and create versions of the SVG for each one. Without such handy, loopable variables, we’re left manually recreating the list by hand and risking getting it wrong and getting out of sync with future themes or theme changes.