### PR TITLE
Simplify theme loop & make it work for all SCSS compilers

### DIFF
--- a/source/css/_settings.themes.scss
+++ b/source/css/_settings.themes.scss
@@ -120,62 +120,57 @@ $themes: (
   )
 );
 
-@each $theme in $themes {
+@each $theme, $shades in $themes {
+  $darker:  map-get($shades, darker);
+  $dark:    map-get($shades, dark);
+  $base:    map-get($shades, base);
+  $light:   map-get($shades, light);
+  $lighter: map-get($shades, lighter);
+
   .#{$theme} {
-    @each $color, $colors in $theme {
-      @each $key, $value in $color {
-        // Text Color
-        .u-theme--color--#{$key},
-        .u-theme--color--#{$key} a,
-        a.u-theme--link-hover--#{$key}:hover,
-        .u-theme--link-hover--#{$key} a:hover {
-          color: $value;
+
+    @each $shade, $color in $shades {
+      // Text Color
+      .u-theme--color--#{$shade},
+      .u-theme--color--#{$shade} a,
+      a.u-theme--link-hover--#{$shade}:hover,
+      .u-theme--link-hover--#{$shade} a:hover {
+        color: $color;
+      }
+
+      // Background Color
+      .u-theme--background-color--#{$shade} {
+        background-color: $color;
+      }
+
+      // Border Color
+      .u-theme--border-color--#{$shade} {
+        border-color: $color;
+
+        &--top {
+          border-top-color: $color;
         }
 
-        // Background Color
-        .u-theme--background-color--#{$key} {
-          background-color: $value;
+        &--bottom {
+          border-bottom-color: $color;
         }
 
-        // Border Color
-        .u-theme--border-color--#{$key} {
-          border-color: $value;
-
-          &--top {
-            border-top-color: $value;
-          }
-
-          &--bottom {
-            border-bottom-color: $value;
-          }
-
-          &--left {
-            border-left-color: $value;
-          }
-
-          &--right {
-            border-right-color: $value;
-          }
+        &--left {
+          border-left-color: $color;
         }
 
-        // SVG fill colors
-        .u-theme--path-fill--#{$key} {
-          path {
-            fill: $value;
-          }
+        &--right {
+          border-right-color: $color;
+        }
+      }
+
+      // SVG fill colors
+      .u-theme--path-fill--#{$shade} {
+        path {
+          fill: $color;
         }
       }
     }
-  }
-}
-
-@each $theme, $shade in $themes {
-  $darker: map-get($shade, darker);
-  $dark: map-get($shade, dark);
-  $base: map-get($shade, base);
-  $light: map-get($shade, light);
-  $lighter: map-get($shade, lighter);
-  .#{$theme} {
 
     // Background transparency
     .u-theme--background-color-trans--darker {


### PR DESCRIPTION
I’m not sure why, but I can’t get the `_settings.themes.scss` file to compile with  my versions of libsass or node-scss or what-have-you. Even pulling the file’s contents into something like [SassMeister](https://www.sassmeister.com) I could only get it to work if I chose the `LibSass v3.5.0.beta.2` compiler option – all the other compilers had errors. If we adjust the loop just slightly, though, as I‘ve done in this commit, it compiles for all of the compilers (including my local ones) and it simplifies the code.

The diff looks kind of funky, but all I did was move the inner-most loop from the first set of loops into the main portion of the second loop, and I adjusted the variable names to make more semantic sense.

---

Here’s an example of the error I was getting: https://www.sassmeister.com/gist/8a22e7abc497e2718239ee12d79d84f5 _(**Note:** I’ve included the `_settings.variables.scss` file contents so the `_settings.themes.scss` file contents don’t start until line 146)_.

And here’s the result of making the change from this pull request: https://www.sassmeister.com/gist/a58cc3591a985cea1fc31c762a378462 _(again, the `_settings.themes.scss` file contents start on line 146)_.