### PR TITLE
#329 fixTo isn’t working in IE 11 or Edge

### DIFF
--- a/source/css/_module.main.scss
+++ b/source/css/_module.main.scss
@@ -146,7 +146,7 @@
   padding-top: 0;
   cursor: pointer;
   background-color: $c-gray--light;
-  margin: 0 auto;
+  margin: 0;
   display: block;
 
   &__logo--inner {
@@ -173,6 +173,8 @@
     width: 100%;
     max-width: rem(80);
     margin: 0 auto;
+    left: 0;
+    right: 0;
 
     @include media('>large') {
       max-width: rem(155);

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -121,9 +121,9 @@
   /**
    * Fixto
    */
-  $('.js-sticky').fixTo('js-sticky-parent', {
+  $('.js-sticky').fixTo('.js-sticky-parent', {
     className: 'sticky-is-active',
-    useNativeSticky: true,
+    useNativeSticky: false,
     zIndex: 9999
   });
 


### PR DESCRIPTION
I turned off use native sticky for IE support. The issue in the script was I was missing a `.` for the parent classname.
Closes #329 