### PR TITLE
#333 - grid tweak (narrow widths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixes Menu overlays the Sabbath column on page load. [#384](https://github.com/adventistchurch/alps/issues/384)
 - Fixes Menu missing items in the drawer on XSmall sizes [#389](https://github.com/adventistchurch/alps/issues/389)
 - Fixes the way the background images are calcuated for the Sabbath column. [#392](https://github.com/adventistchurch/alps/issues/392)
+- Fixes the grid on pages without a Sabbath column to flex out to 4 columns of text instead of 3. [#333](https://github.com/adventistchurch/alps/issues/333)
 
 
 ### Added
 -
-
-
 

--- a/source/_patterns/04-pages/articles/article~no-sabbath@complete.json
+++ b/source/_patterns/04-pages/articles/article~no-sabbath@complete.json
@@ -8,9 +8,9 @@
   "blockquote": true,
   "figure_breakout": false,
   "figure_with_caption": true,
-  "figure_split": false,
+  "figure_split": true,
   "highlight": true,
-  "gallery_block": false,
+  "gallery_block": true,
   "story_block": false,
   "related_posts": true,
 

--- a/source/css/_module.main.scss
+++ b/source/css/_module.main.scss
@@ -44,8 +44,8 @@ html {
     }
 
     @include media('>large') {
-      width: calc(100vw / 7 * 3 - 0.01px);
-      margin-left: calc(100vw / 7 * 1);
+      width: calc(100vw / 7 * 4 - 0.01px);
+      margin-left: 0
     }
 
     @include media('>xxlarge') {


### PR DESCRIPTION
- pull article content to left at smaller breakpoints

@designerbrent 
There is probably more for this, but I have a bit of a disconnect in what I am seeing in patternlab versus from WordPress. Can you point me at a specific page somewhere that is showing this exact behavior so I can get a better sense of what needs adjusting in a real world context?