### PR TITLE
Fixes issue with icon not being displayed in Blocks

### DIFF
--- a/source/css/_objects.blocks.scss
+++ b/source/css/_objects.blocks.scss
@@ -84,6 +84,7 @@
     position: absolute;
     bottom: 0;
     left: 0;
+    z-index: 1;
   }
 
   &--gallery::before {


### PR DESCRIPTION
When Block's image is not set as background image, the `<picture>` element is visible and overlaps the :before pseudo element where the icon is displayed. 

This just adds a `z-index: 1` to `.c-block__icon:before` rule. 