### PR TITLE
versions.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,32 +3,38 @@ A record of the changes made to `ALPS V3`.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2]
+Dynamic versioning
+
+### Added:
+- `versions.json` file with links to all the assets
+
 ## [3.6.1]
-## Fixed:
-- Fixe to accordion content not showing.
+### Fixed:
+- Fixes to accordion content not showing.
 
 ## [3.6.0]
-## Added:
+### Added:
 - Added molecules, components and style sheets for search suggestions.
 
 ## [3.5.7]
-## Fixed:
+### Fixed:
 - Fixed bug with the cursor getting changed for the `.c-accordion__item` intead of `.c-accordion__heading`.
 
 ## [3.5.6]
-## Fixed:
+### Fixed:
 - Fixed bug on `.u-shift--left--1-col--standard` when partial `.hide-sabbath`  applies.
 
 ## [3.5.5]
-## Fixed:
+### Fixed:
 - Fixed bug on `.u-shift--left--1-col--standard` when `.hide-sabbath` applies.
 - Fixed the Support for "start" attribute in `<ol>`. [#460](https://github.com/adventistchurch/alps/issues/460)
 
 ## [3.5.4]
-### Added:
+#### Added:
 - Added depth classes for comments. (For Wordpress). [#458](https://github.com/adventistchurch/alps/pull/458)
 
-### Fixed:
+#### Fixed:
 - Fixed the spacing before the blockquotes.
 
 ## [3.5.3]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
    * of /cdn/<major_version/<version>/ that contains the javascript and css.
    */
   var major_version = "3";
-  var version = "3.6.1";
+  var version = "3.6.2";
 
   grunt.initConfig({
     pkg: pkg,
@@ -427,7 +427,8 @@ module.exports = function (grunt) {
     'images',
     'symlink',
     'copy:prod',
-    'add_comment:prod'
+    'add_comment:prod',
+    'versions'
   ]);
 
   grunt.registerTask('cdn', [
@@ -446,8 +447,35 @@ module.exports = function (grunt) {
     'copy',
     'add_comment:dev'
   ]);
+  grunt.registerTask('versions', 'Create a versions.json file', () => {
+    const versionsFile = 'cdn/versions.json';
+    const changeLogFile = 'CHANGELOG.md';
+    const changeLogData = grunt.file.read(changeLogFile);
 
+    const exprVersions = /^## \[(?<version>[\d.]+)\].*\n(?<description>[^#]*)/gum;
+    const matches = changeLogData.matchAll(exprVersions);
 
+    const versionsData = [];
+
+    for (const m of matches) {
+      const v = m.groups.version;
+      const desc = m.groups.description ? m.groups.description.trim() : '';
+
+      versionsData.push({
+        version: v,
+        description: desc,
+        styles: {
+          main: `https://cdn.adventist.org/alps/3/${v}/css/main.css`,
+        },
+        scripts: {
+          main: `https://cdn.adventist.org/alps/3/${v}/js/script.min.js`,
+          head: `https://cdn.adventist.org/alps/3/${v}/js/head-script.min.js`,
+        },
+      });
+    }
+
+    grunt.file.write(versionsFile, JSON.stringify(versionsData, null, 2));
+  });
 
   /**
    * Default Tasks

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -448,7 +448,7 @@ module.exports = function (grunt) {
     'add_comment:dev'
   ]);
   grunt.registerTask('versions', 'Create a versions.json file', () => {
-    const versionsFile = 'cdn/versions.json';
+    const versionsFile = 'cdn/3/versions.json';
     const changeLogFile = 'CHANGELOG.md';
     const changeLogData = grunt.file.read(changeLogFile);
 


### PR DESCRIPTION
Grunt task `versions` generates `versions.json` file in the `/cdn/3` directory.

* Version data is parsed from CHANGELOG.md. It is important to keep this file valid. 
* Version description is extracted from the line after the version number (before Added, Fixed, or other sections). Example description is on version 3.6.2
* As PR #471 is merged, the build process should run on Node.js LTS (v12).
