### PR TITLE
Changes drawer navigation from drawer to accordion

### DIFF
--- a/source/_patterns/01-molecules/navigation/drawer-navigation.twig
+++ b/source/_patterns/01-molecules/navigation/drawer-navigation.twig
@@ -14,7 +14,6 @@
     <div class="c-drawer__nav">
       <div class="c-drawer__nav-primary">
         {% include '@molecules/navigation/primary-navigation.twig' %}
-        <ul class="c-drawer__subnav u-theme--background-color--darker"></ul>
       </div>
       <div class="c-drawer__nav-secondary">
         {% include '@molecules/navigation/secondary-navigation.twig' %}

--- a/source/_patterns/01-molecules/navigation/drawer-navigation.twig
+++ b/source/_patterns/01-molecules/navigation/drawer-navigation.twig
@@ -14,6 +14,7 @@
     <div class="c-drawer__nav">
       <div class="c-drawer__nav-primary">
         {% include '@molecules/navigation/primary-navigation.twig' %}
+        <ul class="c-drawer__subnav u-theme--background-color--darker"></ul>
       </div>
       <div class="c-drawer__nav-secondary">
         {% include '@molecules/navigation/secondary-navigation.twig' %}

--- a/source/css/_module.header.scss
+++ b/source/css/_module.header.scss
@@ -724,14 +724,6 @@
       padding: $pad $pad 0 ($pad * 2);
       overflow-x: visible;
     }
-
-
-    &.subnav-is-active {
-      @include media("<=medium") {
-        overflow: hidden;
-        height: 100vh;
-      }
-    }
   }
 
   .has-subnav {
@@ -747,10 +739,6 @@
         visibility: visible;
         height: auto;
         z-index: 999;
-
-        @include media("<=medium") {
-          top: 0;
-        }
       }
     }
   }
@@ -762,6 +750,7 @@
   // Drawer Primary Nav
   &__nav-primary {
     z-index: 1;
+    user-select: none;
 
     &.this-is-active {
       z-index: 2;
@@ -810,7 +799,7 @@
     &__list-item {
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: flex-start;
       justify-content: space-between;
       flex-wrap: wrap;
     }
@@ -857,6 +846,18 @@
         margin: auto;
         position: absolute;
         display: inline-block;
+
+        @include media("<=medium") {
+          transform: rotate(90deg);
+        }
+      }
+
+      &.this-is-active {
+        &::after {
+          @include media("<=medium") {
+            transform: rotate(270deg);
+          }
+        }
       }
 
       &::before {
@@ -1021,6 +1022,13 @@
     top: 0;
     transition: none;
 
+    &.this-is-active {
+      height: auto;
+      display: block;
+      opacity: 1;
+      z-index: 3;
+    }
+
     @include media(">medium") {
       transition: all 0.25s ease;
       position: absolute;
@@ -1042,7 +1050,7 @@
 
 
       &:first-child {
-        padding-top: 0;
+        padding-top: $pad / 4;
 
         @include media(">medium") {
           padding-top: $pad / 2;
@@ -1050,7 +1058,7 @@
       }
 
       &:last-child {
-        padding-bottom: 0;
+        padding-bottom: $pad / 4;
 
         @include media(">medium") {
           padding-bottom: $pad / 2;
@@ -1061,10 +1069,6 @@
     &__link {
       padding: ($pad / 4) $pad-mobile;
       white-space: normal;
-
-      @include media("<=medium") {
-        color: $c-white;
-      }
     }
   }
 
@@ -1072,14 +1076,12 @@
     position: relative;
     left: 0;
 
-    @include media(">medium") {
-      &__list-item {
-        background-color: $c-gray--dark;
-      }
+    &__list-item {
+      background-color: $c-gray--dark;
+    }
 
-      &__link {
-        color: $c-white;
-      }
+    &__link {
+      color: $c-white;
     }
   }
 
@@ -1097,12 +1099,6 @@
       &::placeholder {
         color: $c-white;
       }
-    }
-  }
-
-  &__nav {
-    @include media("<=medium") {
-      height: 100%;
     }
   }
 

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -191,29 +191,27 @@
     toggleClasses($(this));
   });
 
-  $('.c-primary-nav__arrow').on('click', function(e) {
+  $('.c-primary-nav__arrow').on('click', function (e) {
     e.stopPropagation();
+    if (getWidth() > 700) return;
+
     $(this).toggleClass('this-is-active');
 
     if ($(this).hasClass('this-is-active')) {
       $('.c-drawer__container').addClass('subnav-is-active');
-      $(this).parent('li').clone(true, true).appendTo('.c-drawer__subnav');
-      $(this).parents('.c-primary-nav__list').addClass('this-is-active');
+      $(this).parent('li').children('.c-subnav').addClass('this-is-active');
+      $(this).parents('.c-primary-nav__list-item').addClass('this-is-active');
       $(this).parents('.c-drawer__nav-primary').addClass('this-is-active');
       $(this).parents('.c-primary-nav').addClass('this-is-active');
-      $(this).parents('.c-drawer__nav').children('.c-drawer__subnav').addClass('this-is-active');
       $(this).parents('.c-drawer__nav').addClass('this-is-active');
     } else {
       $('.c-drawer__container').removeClass('subnav-is-active');
-      $('.c-drawer__subnav li').remove();
-      $('.c-primary-nav__list').removeClass('this-is-active');
+      $(this).parent('li').children('.c-subnav').removeClass('this-is-active');
+      $('.c-primary-nav__list-item').removeClass('this-is-active');
       $('.c-drawer__nav-primary').removeClass('this-is-active');
       $('.c-primary-nav').removeClass('this-is-active');
-      $('.c-drawer__subnav').removeClass('this-is-active');
       $('.c-drawer__nav').removeClass('this-is-active');
     }
-
-    $(this).removeClass('this-is-active');
   });
 
   // Hover effects on drawer submenu not on mobile

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -215,21 +215,22 @@
   });
 
   // Hover effects on drawer submenu not on mobile
-  if (getWidth() > 700) {
-    $('.c-drawer .c-primary-nav__list-item').on('mouseenter', function() {
-      $('.c-drawer__container').addClass('subnav-is-active');
-      $(this).addClass('this-is-active');
-      $(this).parent().addClass('this-is-active');
-      $(this).parent().parent().parent().addClass('this-is-active');
-    });
+  $('.c-drawer .c-primary-nav__list-item').on('mouseenter', function() {
+    if (getWidth() < 700) return;
+    $('.c-drawer__container').addClass('subnav-is-active');
+    $(this).addClass('this-is-active');
+    $(this).parent().addClass('this-is-active');
+    $(this).parent().parent().parent().addClass('this-is-active');
+  });
 
-    $('.c-drawer .c-primary-nav__list-item').on('mouseleave', function() {
-      $('.c-drawer__container').removeClass('subnav-is-active');
-      $(this).removeClass('this-is-active');
-      $(this).parent().removeClass('this-is-active');
-      $(this).parent().parent().parent().removeClass('this-is-active');
-    });
-  }
+  $('.c-drawer .c-primary-nav__list-item').on('mouseleave', function() {
+    if (getWidth() < 700) return;
+    $('.c-drawer__container').removeClass('subnav-is-active');
+    $(this).removeClass('this-is-active');
+    $(this).parent().removeClass('this-is-active');
+    $(this).parent().parent().parent().removeClass('this-is-active');
+  });
+  
 
   // Remove active classes on click of drawer
   $('.c-drawer').on('click', function() {


### PR DESCRIPTION
This replaces the "sub-drawer" behaviour from drawer menu on mobile, with an accordion-like menu.

* Updates some `.c-drawer` styles: 
  - Subnav arrows points up and down in mobile
  - Increases padding in first and last child items
  - Disables user text selection of menu items (may happen on desktop when user makes a double-click on the arrow)
  - Removes some no longer used styles
  - Updates item and link colors
* Updates `$('.c-primary-nav__arrow').on(click)` event
* Removes placeholder `c-drawer__subnav` from  `drawer-navigation.twig` (only used to hold the cloned menu item)