### PR TITLE
fix: Incorrect color gradients in Safari

### DIFF
--- a/source/css/_objects.sections.scss
+++ b/source/css/_objects.sections.scss
@@ -329,7 +329,7 @@
     bottom: 0;
     left: 0;
     height: 120px;
-    background: linear-gradient(to bottom, transparent, rgba($c-white, 1) 60%);
+    background: linear-gradient(to bottom, rgba($c-white, 0), rgba($c-white, 1) 60%);
     z-index: 0;
     pointer-events: none;
     transition: all 0.25s ease;

--- a/source/css/_settings.themes.scss
+++ b/source/css/_settings.themes.scss
@@ -113,7 +113,7 @@
       width: 100%;
       height: 100%;
       z-index: 0;
-      background-image: linear-gradient(to bottom, transparent, rgba($c-gray--light, 0.8) 50%);
+      background-image: linear-gradient(to bottom, rgba($c-gray--light, 0), rgba($c-gray--light, 0.8) 50%);
       pointer-events: none;
     }
 
@@ -126,7 +126,7 @@
       z-index: 0;
       top: 0;
       left: 0;
-      background-image: linear-gradient(to top, transparent, rgba($darker, 0.8) 100%);
+      background-image: linear-gradient(to top, rgba($darker, 0), rgba($darker, 0.8) 100%);
       pointer-events: none;
     }
 
@@ -139,7 +139,7 @@
       z-index: 1;
       top: 0;
       left: 0;
-      background-image: linear-gradient(to left, transparent, rgba($darker, 1) 100%);
+      background-image: linear-gradient(to left, rgba($darker, 0), rgba($darker, 1) 100%);
       pointer-events: none;
     }
 
@@ -152,7 +152,7 @@
       z-index: 1;
       top: 0;
       right: 0;
-      background-image: linear-gradient(to right, transparent, rgba($darker, 1) 100%);
+      background-image: linear-gradient(to right, rgba($darker, 0), rgba($darker, 1) 100%);
       pointer-events: none;
     }
 
@@ -528,7 +528,7 @@
 
       &.u-theme--gradient--bottom::after,
       .u-theme--gradient--bottom::after {
-        background-image: linear-gradient(to bottom, transparent, rgba($darker, 0.8) 50%);
+        background-image: linear-gradient(to bottom, rgba($darker, 0), rgba($darker, 0.8) 50%);
       }
 
       // SVG fill colors

--- a/source/css/_trumps.helper-classes.scss
+++ b/source/css/_trumps.helper-classes.scss
@@ -407,7 +407,7 @@
   width: 100%;
   height: 100%;
   z-index: 0;
-  background: linear-gradient(to bottom, transparent, rgba($c-black, 0.5) 80%);
+  background: linear-gradient(to bottom, rgba($c-black, 0), rgba($c-black, 0.5) 80%);
 }
 
 /**


### PR DESCRIPTION
Adventist.org is currently showing an ugly color gradient on the home page in Safari:

![image](https://user-images.githubusercontent.com/120155/88497808-a63bfe80-cf7e-11ea-9908-804a248ea652.png)

This is Molecules -> Components -> Content Read More.

Safari treats the keyword `transparent` as `rgba(0, 0, 0, 0)` as the [spec](https://www.w3.org/TR/css-color-3/#transparent) says. This causes color-to-color transitions/gradients/etc. to look different than in other browsers where `transparent` is colorless. This PR resolves the incorrect gradients in Safari by replacing all uses of `transparent` in gradients with a `rgba(..., 0)` color-matched equivalent.