### PR TITLE
Fixes background image caption

### DIFF
--- a/source/_patterns/01-molecules/blocks/media-block~background-image.json
+++ b/source/_patterns/01-molecules/blocks/media-block~background-image.json
@@ -1,0 +1,34 @@
+{
+  "media_block_default": {
+    "block_class": "c-block__row l-grid--7-col",
+    "block_img_class": "l-grid-item u-padding--zero--sides",
+    "block_content_class": "l-grid-item u-color--gray u-padding--top u-padding--bottom",
+    "block_title_class": "u-theme--color--darker",
+    "block_meta_class": "u-theme--color--dark",
+    "kicker": false,
+    "title": "Adventist leaders call for international cooperation to end abuse of refugees in Libya",
+    "title_tag": "h3",
+    "background_image": true,
+    "picture": {
+      "img_break_m": "500",
+      "img": {
+        "alt": "Alt Text",
+        "src_s": "//picsum.photos/500/375/?random",
+        "src_m": "//picsum.photos/700/600/?random"
+      },
+      "has_break_l": {
+        "img_break_l": "900",
+        "img": {
+          "src_l": "//picsum.photos/900/700/?random"
+        }
+      },
+      "has_break_xl": false
+    },
+    "datetime": "2018-12-28",
+    "date": "December 28, 2018",
+    "description": "Mauris sit amet augue gravida, dignissim sem maximus, aliquam metus. Maecenas eu consectetur orci, id auctor dui.",
+    "category": "Culture",
+    "url": "/",
+    "caption": "Aliquam erat volutpat. Etiam dui dui, molestie et pulvinar eget, malesuada vitae dui. Nunc non est pulvinar, lacinia augue sit amet, efficitur libero."
+  }
+}

--- a/source/css/_objects.blocks.scss
+++ b/source/css/_objects.blocks.scss
@@ -193,7 +193,16 @@
   }
 
   .o-background-image {
+    position: relative;
     min-height: rem(300);
+
+    .c-block__image-wrap {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
   }
 
   .c-block__content {


### PR DESCRIPTION
Looks like MediaBlock's caption works only when the image is displayed as an `img` tag, but now when is a set as background image (a media block's `.c-block__image-wrap` with `.o-background-image` and `.u-background--cover`)

Issue:

![Issue](https://user-images.githubusercontent.com/76132/89411159-3ddee100-d725-11ea-9825-07d49291bb13.jpg)

With this PR fix:

![Fix](https://user-images.githubusercontent.com/76132/89411229-5f3fcd00-d725-11ea-8c4c-023e04645e8a.jpg)

It also adds a "Media Block's Background Image" variant to display how background image is used in MediaBlocks (and also including a caption)
