### PR TITLE
Fixes aspect ratio in MediaBlock with .o-background-image

### DIFF
--- a/source/_patterns/01-molecules/blocks/media-block.twig
+++ b/source/_patterns/01-molecules/blocks/media-block.twig
@@ -3,53 +3,55 @@
     {% if media_block_default.img or media_block_default.picture %}
       <div
         class="c-block__image {{ media_block_default.block_img_class }}{% if media_block_default.block_type %} c-block__icon c-block__icon--{{ media_block_default.block_type }}{% endif %}{% if media_block_default.background_image %} o-background-image u-background--cover{% endif %}">
-        <div class="c-block__image-wrap {{ media_block_default.block_img_wrap_class }}">
-          {% if media_block_default.background_image %}
-            <style type="text/css">
-              .o-background-image {
-                background-image: url({{ media_block_default.picture.img.src_s | raw }});
-              }
-              @media(min-width: {{ media_block_default.picture.img_break_m ~ 'px' }}) {
+        <div class="c-block__image-outer-wrap">
+          <div class="c-block__image-wrap {{ media_block_default.block_img_wrap_class }}">
+            {% if media_block_default.background_image %}
+              <style type="text/css">
                 .o-background-image {
-                  background-image: url({{ media_block_default.picture.img.src_m | raw }});
+                  background-image: url({{ media_block_default.picture.img.src_s | raw }});
                 }
-              }
-              @media(min-width: {{ media_block_default.picture.has_break_l.img_break_l ~ 'px' }}) {
-                .o-background-image {
-                  background-image: url({{ media_block_default.picture.has_break_l.img.src_l | raw }});
+                @media(min-width: {{ media_block_default.picture.img_break_m ~ 'px' }}) {
+                  .o-background-image {
+                    background-image: url({{ media_block_default.picture.img.src_m | raw }});
+                  }
                 }
-              }
-              @media(min-width: {{ media_block_default.picture.has_break_xl.img_break_xl ~ 'px' }}) {
-                .o-background-image {
-                  background-image: url({{ media_block_default.picture.has_break_xl.img.src_xl | raw }});
+                @media(min-width: {{ media_block_default.picture.has_break_l.img_break_l ~ 'px' }}) {
+                  .o-background-image {
+                    background-image: url({{ media_block_default.picture.has_break_l.img.src_l | raw }});
+                  }
                 }
-              }
-            </style>
-          {% elseif media_block_default.picture %}
-            <picture class="picture">
-              <!--[if IE 9]><video style="display: none;"><![endif]-->
-              {% if media_block_default.picture.has_break_xl %}
-                <source srcset="{{ media_block_default.picture.has_break_xl.img.src_xl }}" media="(min-width: {{ media_block_default.picture.has_break_xl.img_break_xl }}px)">
-              {% endif %}
-              {% if media_block_default.picture.has_break_l %}
-                <source srcset="{{ media_block_default.picture.has_break_l.img.src_l }}" media="(min-width: {{ media_block_default.picture.has_break_l.img_break_l }}px)">
-              {% endif %}
-              <source srcset="{{ media_block_default.picture.img.src_m }}" media="(min-width: {{ media_block_default.picture.img_break_m }}px)">
-              <!--[if IE 9]></video><![endif]-->
-              <img itemprop="image" srcset="{{ media_block_default.picture.img.src_s }}" alt="{{ media_block_default.picture.img.alt }}">
-            </picture>
-          {% elseif media_block_default.img %}
-            <img src="{{ media_block_default.img.src }}" itemprop="image" alt="{{ media_block_default.img.alt }}"/>
-          {% endif %}
-          {% if media_block_default.picture.video %}
-            <div class="c-block__image-video u-spacing--half u-padding u-color--white u-gradient--bottom">
-              <strong>{{ media_block_default.picture.video.title }}</strong>
-              <button href="{{ media_block_default.picture.video.link }}" class="o-button o-button--outline o-button--outline--white"><span class="u-icon u-icon--xs u-space--half--right">{% include '@atoms/icons/icon-play.twig' %}</span>Watch Video</button>
-            </div>
-          {% endif %}
-          {% if media_block_default.caption %}
-            <div class="c-block__caption u-padding--top u-padding--bottom u-color--white-transparent {% if media_block_default.block_type %}u-padding--right u-padding--quad--left{% else %}u-padding--sides{% endif %}">{{ media_block_default.caption }}</div>
-          {% endif %}
+                @media(min-width: {{ media_block_default.picture.has_break_xl.img_break_xl ~ 'px' }}) {
+                  .o-background-image {
+                    background-image: url({{ media_block_default.picture.has_break_xl.img.src_xl | raw }});
+                  }
+                }
+              </style>
+            {% elseif media_block_default.picture %}
+              <picture class="picture">
+                <!--[if IE 9]><video style="display: none;"><![endif]-->
+                {% if media_block_default.picture.has_break_xl %}
+                  <source srcset="{{ media_block_default.picture.has_break_xl.img.src_xl }}" media="(min-width: {{ media_block_default.picture.has_break_xl.img_break_xl }}px)">
+                {% endif %}
+                {% if media_block_default.picture.has_break_l %}
+                  <source srcset="{{ media_block_default.picture.has_break_l.img.src_l }}" media="(min-width: {{ media_block_default.picture.has_break_l.img_break_l }}px)">
+                {% endif %}
+                <source srcset="{{ media_block_default.picture.img.src_m }}" media="(min-width: {{ media_block_default.picture.img_break_m }}px)">
+                <!--[if IE 9]></video><![endif]-->
+                <img itemprop="image" srcset="{{ media_block_default.picture.img.src_s }}" alt="{{ media_block_default.picture.img.alt }}">
+              </picture>
+            {% elseif media_block_default.img %}
+              <img src="{{ media_block_default.img.src }}" itemprop="image" alt="{{ media_block_default.img.alt }}"/>
+            {% endif %}
+            {% if media_block_default.picture.video %}
+              <div class="c-block__image-video u-spacing--half u-padding u-color--white u-gradient--bottom">
+                <strong>{{ media_block_default.picture.video.title }}</strong>
+                <button href="{{ media_block_default.picture.video.link }}" class="o-button o-button--outline o-button--outline--white"><span class="u-icon u-icon--xs u-space--half--right">{% include '@atoms/icons/icon-play.twig' %}</span>Watch Video</button>
+              </div>
+            {% endif %}
+            {% if media_block_default.caption %}
+              <div class="c-block__caption u-padding--top u-padding--bottom u-color--white-transparent {% if media_block_default.block_type %}u-padding--right u-padding--quad--left{% else %}u-padding--sides{% endif %}">{{ media_block_default.caption }}</div>
+            {% endif %}
+          </div>
         </div>
       </div>
       <!-- image -->

--- a/source/css/_objects.blocks.scss
+++ b/source/css/_objects.blocks.scss
@@ -196,6 +196,10 @@
     position: relative;
     min-height: rem(300);
 
+    .c-block__image-outer-wrap {
+      padding-top: 56.25% !important; /* 16:9 aspect ratio */
+    }
+
     .c-block__image-wrap {
       position: absolute;
       top: 0;


### PR DESCRIPTION
- Adds outer wrapper around `.c-block__image-wrap`
- Aspect ratio is fixed to `16:9`


**NOTE**: the `!important` in `.c-block__image-outer-wrap`  is required because `.u-padding--zero--sides` class sets `padding: 0` with an `!important` too. IMHO, `.u-padding--zero--sides` should only set `padding-left` and `padding-right` to `0`, as the name suggests.

 