### PR TITLE
Update styles for menu and under bullet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ A record of the changes made to `ALPS V3`.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.6]
+Update styles for menu and under bullet.
+
+### Fix
+- Position of menu and search icon in the top right corner.
+- Fix Search block for long labels.
+- Under bullet was fixed for Chrome browser.
+
 ## [3.11.5]
 Square Button Styles, add NAD colors.
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
    * of /cdn/<major_version/<version>/ that contains the javascript and css.
    */
   const major_version = "3";
-  const version = "3.11.5";
+  const version = "3.11.6";
 
   /**
    * Split SCSS files by theme

--- a/source/css/_module.header.scss
+++ b/source/css/_module.header.scss
@@ -509,7 +509,7 @@
       }
 
       &.is-priority {
-        display: flex;
+        display: table;
       }
 
       &:hover {
@@ -559,9 +559,10 @@
       }
 
 
-      @include media(">large") {
-        right: rem(75);
-      }
+      // This remove for responsible search icon
+      //@include media(">large") {
+      //  right: rem(75);
+      //}
     }
 
     &__list-item__language.is-priority {

--- a/source/css/_objects.icons.scss
+++ b/source/css/_objects.icons.scss
@@ -22,6 +22,7 @@ $icon-big: rem(65);
 .u-icon--xs svg {
   width: $icon-xsmall;
   height: $icon-xsmall;
+  margin-bottom: 1px;
 }
 
 .u-icon--s,

--- a/source/css/_objects.text.scss
+++ b/source/css/_objects.text.scss
@@ -580,7 +580,7 @@ ul:not(.c-breadcrumbs__list):not(.o-inline-list) {
 
       li {
         &::before {
-          content: "\002010";
+          content: "\002012";
         }
       }
     }


### PR DESCRIPTION
Fix:
- Position of menu and search icon in the top right corner.
- Fix Search block for long labels.
- Under bullet was fixed for Chrome browser.