### PR TITLE
0000: Release 3.12.2 preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ A record of the changes made to `ALPS V3`.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.2]
+- Update global css styles file for button o-button-toggle class. [#594](https://github.com/adventistchurch/alps/pull/594)
+- Fix for slick dots container overlap. [#593](https://github.com/adventistchurch/alps/pull/593)
+- Changes to allow WP theme to control logo color. [#592](https://github.com/adventistchurch/alps/pull/592)
+
 ## [3.12.1]
 - Update build process for CDN (add build css for WP page builder editor).
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
    * of /cdn/<major_version/<version>/ that contains the javascript and css.
    */
   const major_version = "3";
-  const version = "3.12.1";
+  const version = "3.12.2";
 
   /**
    * Split SCSS files by theme


### PR DESCRIPTION
Changes:
- Update global css styles file for button o-button-toggle class;
- Fix for slick dots container overlap;
- Changes to allow WP theme to control logo color.

#0000-Release